### PR TITLE
allow public assignment to output variables

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -18,7 +18,7 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.10.0
       with:
         repo: torsion-labs/arkworks-bridge
-        tag: v1.0.0-rc1
+        tag: v1.0.0-rc2
 
     - uses: cachix/install-nix-action@v24
       with:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,4 +10,4 @@ import qualified Test.Snarkl.Unit.Programs as Programs
 import Prelude hiding (return, (+), (>>=))
 
 main :: IO ()
-main = defaultMain "prog" (Programs.prog2 1 :: Comp 'TField F_BN128)
+main = defaultMain "prog" (return $ Programs.pow 4 (fromField 3) :: Comp 'TField F_BN128)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,4 +10,4 @@ import qualified Test.Snarkl.Unit.Programs as Programs
 import Prelude hiding (return, (+), (>>=))
 
 main :: IO ()
-main = defaultMain "prog" (return $ Programs.pow 4 (fromField 3) :: Comp 'TField F_BN128)
+main = defaultMain "prog" Programs.prog1

--- a/src/Snarkl/CLI/Compile.hs
+++ b/src/Snarkl/CLI/Compile.hs
@@ -22,7 +22,7 @@ import Data.Typeable (Typeable)
 import Options.Applicative (CommandFields, Mod, Parser, command, execParser, fullDesc, header, help, helper, info, long, progDesc, showDefault, strOption, subparser, switch, value, (<**>))
 import Snarkl.AST (Comp, InputVariable (PrivateInput))
 import Snarkl.CLI.Common (mkConstraintsFilePath, mkInputsFilePath, mkR1CSFilePath, writeFileWithDir)
-import Snarkl.Common (InputVar (PrivateInputVar, PublicInputVar))
+import Snarkl.Common (InputVar (OutputVar, PrivateInputVar, PublicInputVar))
 import Snarkl.Compile
   ( SimplParam (RemoveUnreachable, Simplify),
     TExpPkg (TExpPkg),
@@ -100,9 +100,10 @@ compile CompileOpts {..} name comp = do
       (r1cs, scs, privateInputMap) = compileTExpToR1CS simpl texpPkg
       publicInputs = map PublicInputVar . cs_public_in_vars . unSimplifiedConstraintSystem $ scs
       privateInputs = map (uncurry PrivateInputVar) $ Map.toList privateInputMap
+      outputs = map OutputVar . cs_out_vars . unSimplifiedConstraintSystem $ scs
   let r1csFP = mkR1CSFilePath r1csOutput name
   writeFileWithDir r1csFP $ toJSONLines r1cs
   putStrLn $ "Wrote R1CS to " <> r1csFP
   let inputsFP = mkInputsFilePath inputsOutput name
-  writeFileWithDir inputsFP $ toJSONLines (publicInputs <> privateInputs)
+  writeFileWithDir inputsFP $ toJSONLines (publicInputs <> privateInputs <> outputs)
   putStrLn $ "Wrote inputs to " <> inputsFP

--- a/src/Snarkl/Common.hs
+++ b/src/Snarkl/Common.hs
@@ -205,6 +205,7 @@ data InputAssignment k
   = PublicInputAssignment Var k
   | PrivateInputAssignment String Var k
   | OutputAssignment Var k
+  deriving (Show)
 
 instance Functor InputAssignment where
   fmap f (PublicInputAssignment v k) = PublicInputAssignment v (f k)

--- a/src/Snarkl/Common.hs
+++ b/src/Snarkl/Common.hs
@@ -161,6 +161,7 @@ instance A.FromJSON ConstraintHeader where
 data InputVar
   = PublicInputVar Var
   | PrivateInputVar String Var
+  | OutputVar Var
 
 instance A.ToJSON InputVar where
   toJSON (PublicInputVar v) =
@@ -174,16 +175,22 @@ instance A.ToJSON InputVar where
         "name" A..= name,
         "var" A..= v
       ]
+  toJSON (OutputVar v) =
+    A.object
+      [ "tag" A..= ("output" :: String),
+        "var" A..= v
+      ]
 
-splitInputVars :: [InputVar] -> ([Var], Map.Map String Var)
+splitInputVars :: [InputVar] -> ([Var], Map.Map String Var, [Var])
 splitInputVars =
   foldr
-    ( \iv (pubs, privs) ->
+    ( \iv (pubs, privs, outputs) ->
         case iv of
-          PublicInputVar v -> (v : pubs, privs)
-          PrivateInputVar name v -> (pubs, Map.insert name v privs)
+          PublicInputVar v -> (v : pubs, privs, outputs)
+          PrivateInputVar name v -> (pubs, Map.insert name v privs, outputs)
+          OutputVar v -> (pubs, privs, v : outputs)
     )
-    ([], Map.empty)
+    ([], Map.empty, [])
 
 instance A.FromJSON InputVar where
   parseJSON = A.withObject "InputVar" $ \v -> do
@@ -191,15 +198,18 @@ instance A.FromJSON InputVar where
     case tag of
       ("public" :: String) -> PublicInputVar <$> v A..: "var"
       ("private" :: String) -> PrivateInputVar <$> v A..: "name" <*> v A..: "var"
+      ("output" :: String) -> OutputVar <$> v A..: "var"
       _ -> fail $ "unknown tag: " <> tag
 
 data InputAssignment k
   = PublicInputAssignment Var k
   | PrivateInputAssignment String Var k
+  | OutputAssignment Var k
 
 instance Functor InputAssignment where
   fmap f (PublicInputAssignment v k) = PublicInputAssignment v (f k)
   fmap f (PrivateInputAssignment name v k) = PrivateInputAssignment name v (f k)
+  fmap f (OutputAssignment v k) = OutputAssignment v (f k)
 
 instance (PrimeField k) => A.ToJSON (InputAssignment k) where
   toJSON (PublicInputAssignment v k) =
@@ -215,6 +225,12 @@ instance (PrimeField k) => A.ToJSON (InputAssignment k) where
         "var" A..= v,
         "value" A..= FieldElem k
       ]
+  toJSON (OutputAssignment v k) =
+    A.object
+      [ "tag" A..= ("output" :: String),
+        "var" A..= v,
+        "value" A..= FieldElem k
+      ]
 
 instance (PrimeField k) => A.FromJSON (InputAssignment k) where
   parseJSON = A.withObject "InputAssignment" $ \v -> do
@@ -222,14 +238,16 @@ instance (PrimeField k) => A.FromJSON (InputAssignment k) where
     case tag of
       ("public" :: String) -> PublicInputAssignment <$> v A..: "var" <*> (unFieldElem <$> v A..: "value")
       ("private" :: String) -> PrivateInputAssignment <$> v A..: "name" <*> v A..: "var" <*> (unFieldElem <$> v A..: "value")
+      ("output" :: String) -> OutputAssignment <$> v A..: "var" <*> (unFieldElem <$> v A..: "value")
       _ -> fail $ "unknown tag: " <> tag
 
-splitInputAssignments :: [InputAssignment k] -> ([k], Map.Map (String, Var) k)
+splitInputAssignments :: [InputAssignment k] -> ([k], Map.Map (String, Var) k, [(Var, k)])
 splitInputAssignments =
   foldr
-    ( \ia (pubs, privs) ->
+    ( \ia (pubs, privs, outputs) ->
         case ia of
-          PublicInputAssignment _ k -> (k : pubs, privs)
-          PrivateInputAssignment name v k -> (pubs, Map.insert (name, v) k privs)
+          PublicInputAssignment _ k -> (k : pubs, privs, outputs)
+          PrivateInputAssignment name v k -> (pubs, Map.insert (name, v) k privs, outputs)
+          OutputAssignment var val -> (pubs, privs, (var, val) : outputs)
     )
-    ([], Map.empty)
+    ([], Map.empty, [])

--- a/tests/Test/ArkworksBridge.hs
+++ b/tests/Test/ArkworksBridge.hs
@@ -11,6 +11,7 @@ import Snarkl.Backend.R1CS.R1CS (witnessInputs)
 import Snarkl.CLI.Common (mkInputsFilePath, mkR1CSFilePath, mkWitnessFilePath)
 import Snarkl.Common (Assgn (Assgn), FieldElem (FieldElem))
 import Snarkl.Compile (SimplParam, compileCompToR1CS)
+import Snarkl.Constraint (ConstraintSystem (cs_public_in_vars), SimplifiedConstraintSystem (unSimplifiedConstraintSystem))
 import Snarkl.Toplevel (wit_of_cs)
 import qualified System.Exit as GHC
 import System.Process (createProcess, shell, waitForProcess)
@@ -37,6 +38,7 @@ runCMD (CreateTrustedSetup rootDir name simpl c) = do
   waitForProcess hdl
 runCMD (CreateProof rootDir name simpl c inputs) = do
   let (r1cs, simplifiedCS, _) = compileCompToR1CS simpl c
+  let public_in_vars = cs_public_in_vars (unSimplifiedConstraintSystem simplifiedCS)
       witness = wit_of_cs inputs Map.empty simplifiedCS
       r1csFilePath = mkR1CSFilePath rootDir name
       witsFilePath = mkWitnessFilePath rootDir name

--- a/tests/Test/Snarkl/UnitSpec.hs
+++ b/tests/Test/Snarkl/UnitSpec.hs
@@ -294,7 +294,7 @@ spec = do
       it "36-1" $ test_comp @F_BN128 [Simplify] prog36 [0] `shouldReturn` Right 10
       it "36-2" $ test_comp @F_BN128 [Simplify] prog36 [1] `shouldReturn` Right 7
 
-  describe "Keccak Tests" $ do
-    describe "keccak" $ do
-      it "keccak-2" $ test_comp @F_BN128 [Simplify] (keccak1 2) (fromIntegral <$> input_vals) `shouldReturn` Right 1
-      it "keccak-2" $ test_comp @F_BN128 [Simplify] (keccak1 5) (fromIntegral <$> input_vals) `shouldReturn` Right 1
+    describe "Keccak Tests" $ do
+      describe "keccak" $ do
+        it "keccak-2" $ test_comp @F_BN128 [Simplify] (keccak1 2) (fromIntegral <$> input_vals) `shouldReturn` Right 1
+        it "keccak-2" $ test_comp @F_BN128 [Simplify] (keccak1 5) (fromIntegral <$> input_vals) `shouldReturn` Right 1

--- a/tests/Test/Snarkl/UnitSpec.hs
+++ b/tests/Test/Snarkl/UnitSpec.hs
@@ -294,7 +294,7 @@ spec = do
       it "36-1" $ test_comp @F_BN128 [Simplify] prog36 [0] `shouldReturn` Right 10
       it "36-2" $ test_comp @F_BN128 [Simplify] prog36 [1] `shouldReturn` Right 7
 
-    describe "Keccak Tests" $ do
+    describe "Keccak Tests" $
       describe "keccak" $ do
         it "keccak-2" $ test_comp @F_BN128 [Simplify] (keccak1 2) (fromIntegral <$> input_vals) `shouldReturn` Right 1
         it "keccak-2" $ test_comp @F_BN128 [Simplify] (keccak1 5) (fromIntegral <$> input_vals) `shouldReturn` Right 1


### PR DESCRIPTION
There is a very common use case for zero knowledge proving where the output variable is a public input, usually a boolean `0` or `1` in the literature where you are trying to decide membership in a language. 